### PR TITLE
Fix webserver.Dockerfile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,5 @@
 build:
-	docker build -f docker/webserver.Dockerfile -t minitwit/webserver --target development . && \
-	docker build -f docker/webserver.Dockerfile -t minitwit/tests --target test .
+	docker build -f docker/webserver.Dockerfile -t minitwit/webserver
 
 start:
 	make build && \

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,9 @@
 build:
-	docker build -f docker/webserver.Dockerfile -t minitwit/webserver
+	docker build -f docker/webserver.Dockerfile -t minitwit/webserver .
 
 start:
 	make build && \
-	docker run --detach -p 8080:8080 --name minitwit-webserver minitwit/webserver:latest
-
-stop:
-	docker stop minitwit-webserver
-	docker stop minitwit-tests
+	docker run --detach -p 8080:8080 -p 8081:8081 minitwit/webserver:latest
 
 test:
 	make build && \

--- a/docker/webserver.Dockerfile
+++ b/docker/webserver.Dockerfile
@@ -1,17 +1,13 @@
 # Bullseye is the latest, stable version as of 09/02/2022
 FROM golang:bullseye as base
 WORKDIR /src
-COPY ./go/ ./
+COPY ./src ./
+
+WORKDIR /src/webserver
 RUN go mod tidy
 RUN go mod download
-
-FROM base as test
-CMD ["go", "test"]
-
-FROM base as build
 RUN go build -o /minitwit
 
-FROM base as development
 EXPOSE 8080
-RUN go build -o /minitwit
+EXPOSE 8081
 ENTRYPOINT [ "/minitwit" ]

--- a/src/webserver/server.go
+++ b/src/webserver/server.go
@@ -13,11 +13,11 @@ func main() {
 	go func() {
 		r := mux.NewRouter()
 		simulator.SetupRoutes(r)
-		log.Fatalln(http.ListenAndServe("localhost:8081", r))
+		log.Fatalln(http.ListenAndServe(":8081", r))
 	}()
 
 	// Setup minitwit "website"
 	r := mux.NewRouter()
 	minitwit.SetupRoutes(r)
-	log.Fatalln(http.ListenAndServe("localhost:8080", r))
+	log.Fatalln(http.ListenAndServe(":8080", r))
 }


### PR DESCRIPTION
Closes #103 
Closes #59 

Fix issues we were having with Dockerfile:

Cannot use `localhost:PORT` with Docker. Instead use `:PORT`.
Simplify the Dockerfile to suit production needs.